### PR TITLE
Flushes the buffer at every message so the consumer can immediately them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub fn setup_logger(log_thread: bool, rust_log: LevelFilter) {
 
         let local_time: DateTime<Local> = Local::now();
         let time_str = local_time.format("%H:%M:%S%.3f").to_string();
-        write!(formatter, "{} {}{} - {} - {}\n", time_str, thread_name, record.level(), record.target(), record.args())
+        writeln!(formatter, "{} {}{} - {} - {}", time_str, thread_name, record.level(), record.target(), record.args())
     };
 
     let mut builder = Builder::new();

--- a/src/modes/consume.rs
+++ b/src/modes/consume.rs
@@ -18,22 +18,25 @@ pub async fn run_async_consume_topic<Interface: KafkaInterface>(_interface: Inte
     let mut stdout = BufWriter::new(tokio::io::stdout());
     loop {
         match timeout_at(Instant::now() + timeout, consumer.recv()).await {
-            Ok(Ok(msg)) => match input_config.format {
-                SerdeFormat::Text => {
-                    stdout.write(&msg.key).await?;
-                    stdout.write(input_config.key_delim.as_bytes()).await?;
-                    stdout.write(&msg.payload).await?;
-                    stdout.write(input_config.msg_delim.as_bytes()).await?;
-                },
-                SerdeFormat::Json => {
-                    let x = serde_json::to_string(&msg)?;
-                    stdout.write(x.as_bytes()).await?;
-                    stdout.write(input_config.msg_delim.as_bytes()).await?;
-                },
-                SerdeFormat::Regex(r) => {
-                    unimplemented!("Does not supports {} yet", r);
-                },
-            },
+            Ok(Ok(msg)) => {
+                match input_config.format {
+                    SerdeFormat::Text => {
+                        stdout.write(&msg.key).await?;
+                        stdout.write(input_config.key_delim.as_bytes()).await?;
+                        stdout.write(&msg.payload).await?;
+                        stdout.write(input_config.msg_delim.as_bytes()).await?;
+                    }
+                    SerdeFormat::Json => {
+                        let x = serde_json::to_string(&msg)?;
+                        stdout.write(x.as_bytes()).await?;
+                        stdout.write(input_config.msg_delim.as_bytes()).await?;
+                    }
+                    SerdeFormat::Regex(r) => {
+                        unimplemented!("Does not supports {} yet", r);
+                    }
+                }
+                stdout.flush().await?
+            }
             Ok(Err(err)) => Err(err)?,
             Err(_err) => break,
         }

--- a/src/modes/consume.rs
+++ b/src/modes/consume.rs
@@ -16,26 +16,41 @@ pub async fn run_async_consume_topic<Interface: KafkaInterface>(_interface: Inte
 
     let timeout = get_delay(input_config.exit_on_done);
     let mut stdout = BufWriter::new(tokio::io::stdout());
+    let mut bytes_read = 0;
+    let mut messages_count = 0;
     loop {
         match timeout_at(Instant::now() + timeout, consumer.recv()).await {
             Ok(Ok(msg)) => {
                 match input_config.format {
                     SerdeFormat::Text => {
-                        stdout.write(&msg.key).await?;
-                        stdout.write(input_config.key_delim.as_bytes()).await?;
-                        stdout.write(&msg.payload).await?;
-                        stdout.write(input_config.msg_delim.as_bytes()).await?;
+                        bytes_read += stdout.write(&msg.key).await?;
+                        bytes_read += stdout.write(input_config.key_delim.as_bytes()).await?;
+                        bytes_read += stdout.write(&msg.payload).await?;
+                        bytes_read += stdout.write(input_config.msg_delim.as_bytes()).await?;
                     }
                     SerdeFormat::Json => {
                         let x = serde_json::to_string(&msg)?;
-                        stdout.write(x.as_bytes()).await?;
-                        stdout.write(input_config.msg_delim.as_bytes()).await?;
+                        bytes_read += stdout.write(x.as_bytes()).await?;
+                        bytes_read += stdout.write(input_config.msg_delim.as_bytes()).await?;
                     }
                     SerdeFormat::Regex(r) => {
-                        unimplemented!("Does not supports {} yet", r);
+                        unimplemented!("Does not support {} yet", r);
                     }
+                };
+                messages_count += 1;
+                let should_flush = {
+                    match (input_config.msg_count_flush, input_config.msg_bytes_flush) {
+                        (None, None) => false,
+                        (None, Some(bytes_treshold)) => bytes_read >= bytes_treshold,
+                        (Some(count_treshold), None) => messages_count >= count_treshold,
+                        (Some(count_treshold), Some(bytes_treshold)) => bytes_read >= bytes_treshold || messages_count >= count_treshold,
+                    }
+                };
+                if should_flush {
+                    stdout.flush().await?;
+                    bytes_read = 0;
+                    messages_count = 0;
                 }
-                stdout.flush().await?
             }
             Ok(Err(err)) => Err(err)?,
             Err(_err) => break,


### PR DESCRIPTION
Without this, the user will only see the messages when the async thing times out. Which is not entirely useful IMO.

I think one issue is that if we are listening from the beginning, we will flush at every interval. I think what we can do is to have a buffer that can store a certain amount of bytes and flushes every messages (up to the message delimiter). But this poses an issue with messages that are larger than the buffer.

So I am not sure if there's any async tricks to stdout. I am new to this ^^

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>