### PR TITLE
feat: support reading from file and support no format

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -106,7 +106,8 @@ pub fn format() -> Arg<'static> {
         .long("format")
         .help(
             "Serialize/Deserialize format. Supported formats: json, text. \
-        If not specified, it simply use every lines as the payload. Key of message will be null.",
+        If not specified, it simply uses every lines as the payload. \
+        The Key of every message will be null.",
         )
         .default_value(FORMAT_DEFAULT)
 }

--- a/src/modes/consume.rs
+++ b/src/modes/consume.rs
@@ -31,6 +31,9 @@ pub async fn run_async_consume_topic<Interface: KafkaInterface>(
             Ok(Ok(msg)) => {
                 log::trace!("Received message:\n{:#?}", msg);
                 match input_config.format {
+                    SerdeFormat::None => {
+                        bytes_read += stdout.write(&msg.payload).await?;
+                    }
                     SerdeFormat::Text => {
                         bytes_read += stdout.write(&msg.key).await?;
                         bytes_read += stdout.write(input_config.key_delim.as_bytes()).await?;


### PR DESCRIPTION
For reading from file:

```sh
target/debug/kafcat -P -b 127.0.0.1:9092 -t example_topic_1 -- ./tests/testdata/example_topic_1
```

By default, we do not use any message format. This is the same behavior as kcat.