### PR TITLE
release: bump to v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafcat"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["qiujiangkun <qiujiangkun@foxmail.com>"]
 edition = "2018"
 description = "cat but with kafka"


### PR DESCRIPTION
Since we have several fixes merged and looks like we didn't have any release before, can we bump to a new version and publish the release via `cargo release`?