### PR TITLE
ci: create release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: release ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-unknown-linux-musl, x86_64-apple-darwin]
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and release
+        uses: rust-build/rust-build.action@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUSTTARGET: ${{ matrix.target }}
+          EXTRA_FILES: "README.md LICENSE"


### PR DESCRIPTION
https://github.com/marketplace/actions/rust-release-binary

We may use this action to create binary release, so that users can download prebuilts rather than build from source. This requires the admin @qiujiangkun  to set a secret called `GITHUB_TOKEN` to your [Personal access tokens]( https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)

