### PR TITLE
ci: the last pr for binary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,63 +16,22 @@
 name: release
 on:
   push:
-    # Enable when testing release infrastructure on a branch.
-    # branches:
-    # - ag/work
     tags:
     - "[0-9]+.[0-9]+.[0-9]+"
 jobs:
   create-release:
     name: create-release
-    runs-on: ubuntu-latest
-    # env:
-      # Set to force version number, e.g., when no tag exists.
-      # REL_VERSION: TEST-0.0.0
-    outputs:
-      upload_url: ${{ steps.release.outputs.upload_url }}
-      rel_version: ${{ env.REL_VERSION }}
-    steps:
-      - name: Get the release version from the tag
-        shell: bash
-        if: env.REL_VERSION == ''
-        run: |
-          # Apparently, this is the right way to get a tag name. Really?
-          #
-          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "REL_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: ${{ env.REL_VERSION }}"
-      - name: Create GitHub release
-        id: release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.REL_VERSION }}
-          release_name: ${{ env.REL_VERSION }}
-
-  build-release:
-    name: build-release
-    needs: ['create-release']
     runs-on: ${{ matrix.os }}
     env:
-      # For some builds, we use cross to test on 32-bit and big-endian
-      # systems.
-      CARGO: cargo
-      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS: ""
-      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
-      TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
-      # Build static releases with PCRE2.
-      PCRE2_SYS_STATIC: 1
     strategy:
       matrix:
         build: [linux, macos]
         include:
         - build: linux
           os: ubuntu-18.04
-          target: x86_64-unknown-linux-musl
+          target: x86_64-unknown-linux-gnu
         - build: macos
           os: macos-latest
           target: x86_64-apple-darwin
@@ -80,11 +39,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    - name: Install packages (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install openssl
 
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
@@ -98,42 +52,23 @@ jobs:
       shell: bash
       run: |
         cargo install cross
-        echo "CARGO=cross" >> $GITHUB_ENV
-        echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-        echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
-
-    - name: Show command used for Cargo
-      run: |
-        echo "cargo command is: ${{ env.CARGO }}"
-        echo "target flag is: ${{ env.TARGET_FLAGS }}"
-        echo "target dir is: ${{ env.TARGET_DIR }}"
 
     - name: Build release binary
-      run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
+      run: cross build --release --target ${{ matrix.target }}
 
-    - name: Strip release binary (linux and macos)
+    - name: Build Archive
       if: matrix.build == 'linux' || matrix.build == 'macos'
-      run: strip "target/${{ matrix.target }}/release/kafcat"
-
-    - name: Build archive
-      shell: bash
       run: |
-        outdir="$(ci/cargo-out-dir "${{ env.TARGET_DIR }}")"
-        staging="kafcat-${{ needs.create-release.outputs.rel_version }}-${{ matrix.target }}"
-        mkdir -p "$staging"
-        cp {README.md,LICENSE} "$staging/"
+        outdir=kafcat-${{ matrix.target }}
+        mkdir "$outdir"
+        mv target/${{ matrix.target }}/release/kafcat "$outdir"
+        mv README.md LICENSE "$outdir"
+        strip "$outdir/kafcat"
+        tar czf "$outdir.tar.gz" "$outdir"
+        echo "ASSET=$outdir.tar.gz" >> $GITHUB_ENV
 
-        # The man page is only generated on Unix systems. ¯\_(ツ)_/¯
-        cp "target/${{ matrix.target }}/release/kafcat" "$staging/"
-        tar czf "$staging.tar.gz" "$staging"
-        echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
-
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
-        asset_content_type: application/octet-stream
+        files: |
+          ${{ env.ASSET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install packages (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install openssl
-
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rdkafka = "0.28"
+rdkafka = { version = "0.28", features = ["ssl-vendored"] }
 kafka = "0.8.0"
 clap = { version = "3", features = ["cargo"] }
 log = "0.4.14"
@@ -36,5 +36,3 @@ shellexpand = "2.1"
 
 [dev-dependencies]
 assert_cmd = "2"
-
-


### PR DESCRIPTION
I have locally tested in my branch and it will create two releases, 
- kafcat-x86_64-apple-darwin.tar.gz
- kafcat-x86_64-unknown-linux-gnu.tar.gz

And there is no problem with the compiled executable. https://github.com/neverchanje/kafcat/releases